### PR TITLE
Issue 8: Add scanmode deny

### DIFF
--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -81,13 +81,8 @@ class scanner extends \core\antivirus\scanner {
         }
 
         // Set scanmode.
-        $scanmodeconfig = self::get_config('scanmode');
-        $scanmode = [];
-        if ($scanmodeconfig == "allow") {
-            $scanmode = [true, false];
-        } else if ($scanmodeconfig == "deny") {
-            $scanmode = [false, true]; // Switch scanmode.
-        } else {
+        $scanmodeconfig = $this->get_config('scanmode');
+        if ($scanmodeconfig !== "allow" && $scanmodeconfig !== "deny") {
             // Invalid scanmode config, fail safe and block all uploads.
             return self::SCAN_RESULT_FOUND;
         }
@@ -108,24 +103,19 @@ class scanner extends \core\antivirus\scanner {
             $detectedmimetype = 'application/vnd.moodle.backup';
         }
 
-        // Check if result is in the array of allowed mimetypes.
-        $return = in_array($detectedmimetype, $this->configuredmimetypes);
-        if ($return == $scanmode[0]) {
+        // In deny mode, block if the type matches the list. In allow mode, block if it doesn't match.
+        $ismatch = in_array($detectedmimetype, $this->configuredmimetypes);
+        $isblocked = ($scanmodeconfig === 'deny') ? $ismatch : !$ismatch;
+
+        if (!$isblocked) {
             return self::SCAN_RESULT_OK;
-        } else if ($return == $scanmode[1]) {
-            // MIME type not allowed! custom exception will be throw and not return back at \core\antivirus\manager::scan_file.
-            unlink($file);
-            require_once('mimeblocker_exception.php');
-            if ($scanmodeconfig == "allow") {
-                throw new mimeblocker_exception('virusfoundallow', '', ['types' => self::get_file_extensions()]);
-            }
-            if ($scanmodeconfig == "deny") {
-                throw new mimeblocker_exception('virusfounddeny', '', ['types' => self::get_file_extensions()]);
-            }
         }
 
-        // Unreachable in practice, but return a valid constant as a safeguard.
-        return self::SCAN_RESULT_ERROR;
+        // MIME type not allowed — delete file and throw exception.
+        unlink($file);
+        require_once('mimeblocker_exception.php');
+        $errorkey = ($scanmodeconfig === 'deny') ? 'virusfounddeny' : 'virusfoundallow';
+        throw new mimeblocker_exception($errorkey, '', ['types' => self::get_file_extensions()]);
     }
 
     /**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -147,9 +147,7 @@ class scanner extends \core\antivirus\scanner {
             }
         }
 
-        if (count($extensions)) {
-            return $extensions;
-        }
+        return $extensions;
     }
 
     /**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -38,9 +38,9 @@ defined('MOODLE_INTERNAL') || die();
 class scanner extends \core\antivirus\scanner {
 
     /**
-     * @var array A semicolon separated string of allowed or denied mimetypes.
+     * @var array Configured mimetypes to allow or deny.
      */
-    public $configuredmimetypes;
+    protected $configuredmimetypes;
 
     /**
      * @var string The active scan mode ('allow' or 'deny'), set during scan_file().
@@ -159,11 +159,10 @@ class scanner extends \core\antivirus\scanner {
     }
 
     /**
-     *
      * To identify extension of the MIME type.
      *
-     * @param string MIME type
-     * @return array MIME type extention
+     * @param string $mime MIME type.
+     * @return array MIME type extensions.
      */
     public static function extension_filter($mime) {
         $types = \core_filetypes::get_types();
@@ -178,7 +177,7 @@ class scanner extends \core\antivirus\scanner {
     }
 
     /**
-     * To get comma separate extension on the basis of allowed or denxed MIME types configure by administrator.
+     * To get comma separated extensions on the basis of allowed or denied MIME types configured by administrator.
      *
      * @return string types of allowed extensions based on allowed MIME types.
      */

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -55,7 +55,7 @@ class scanner extends \core\antivirus\scanner {
     public function __construct() {
         parent::__construct();
         // Create array of allowed mimetypes based on config setting.
-        $this->configuredmimetypes = explode(";", trim($this->get_config('mimetypes')));
+        $this->configuredmimetypes = explode(";", trim((string) $this->get_config('mimetypes')));
     }
 
     /**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -88,19 +88,15 @@ class scanner extends \core\antivirus\scanner {
         } else if ($scanmodeconfig == "deny") {
             $scanmode = [false, true]; // Switch scanmode.
         } else {
+            // Invalid scanmode config, fail safe and block all uploads.
             return self::SCAN_RESULT_FOUND;
         }
 
-        $detectedmimetype = null;
-        // Check mimetype using php functions.
-        if (function_exists('finfo_file')) {
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $detectedmimetype = finfo_file($finfo, $file);
-            finfo_close($finfo);
-        } else if (function_exists('mime_content_type')) {
-            // Deprecated, only when finfo isn't available.
-            debugging("Note finfo_file() php function not available, falling back to depracated mime_content_type()");
-            $detectedmimetype = mime_content_type($file);
+        $detectedmimetype = $this->detect_mimetype($file);
+
+        if ($detectedmimetype === null) {
+            debugging("Could not detect MIME type for file ($file). No detection function available.");
+            return self::SCAN_RESULT_ERROR;
         }
 
         // MoodleNet compatibility, Ignore course backup file.
@@ -129,6 +125,26 @@ class scanner extends \core\antivirus\scanner {
         }
 
         return $return;
+    }
+
+    /**
+     * Detect the MIME type of a file.
+     *
+     * @param string $file Full path to the file.
+     * @return string|null The detected MIME type, or null if detection is not available.
+     */
+    protected function detect_mimetype($file) {
+        if (function_exists('finfo_file')) {
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            $mimetype = finfo_file($finfo, $file);
+            finfo_close($finfo);
+            return $mimetype ?: null;
+        } else if (function_exists('mime_content_type')) {
+            debugging("Note finfo_file() php function not available, falling back to deprecated mime_content_type()");
+            $mimetype = mime_content_type($file);
+            return $mimetype ?: null;
+        }
+        return null;
     }
 
     /**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -38,9 +38,14 @@ defined('MOODLE_INTERNAL') || die();
 class scanner extends \core\antivirus\scanner {
 
     /**
-     * @var string A semicolon separated string of allowed or denyed mimetypes.
+     * @var array A semicolon separated string of allowed or denied mimetypes.
      */
     public $configuredmimetypes;
+
+    /**
+     * @var string The active scan mode ('allow' or 'deny'), set during scan_file().
+     */
+    private $scanmodeconfig = 'allow';
 
     /**
      * Class constructor.
@@ -111,11 +116,26 @@ class scanner extends \core\antivirus\scanner {
             return self::SCAN_RESULT_OK;
         }
 
-        // MIME type not allowed — delete file and throw exception.
-        unlink($file);
-        require_once('mimeblocker_exception.php');
-        $errorkey = ($scanmodeconfig === 'deny') ? 'virusfounddeny' : 'virusfoundallow';
-        throw new mimeblocker_exception($errorkey, '', ['types' => self::get_file_extensions()]);
+        // MIME type not allowed — let the antivirus manager handle quarantine, cleanup and messaging.
+        $this->scanmodeconfig = $scanmodeconfig;
+        return self::SCAN_RESULT_FOUND;
+    }
+
+    /**
+     * Return custom virus found message based on the active scan mode.
+     *
+     * Overrides the base method so the antivirus manager displays a message
+     * that tells the user which file types are allowed or denied.
+     *
+     * @return array array of string, component and placeholders for the exception.
+     */
+    public function get_virus_found_message() {
+        $stringkey = ($this->scanmodeconfig === 'deny') ? 'virusfounddeny' : 'virusfoundallow';
+        return [
+            'string' => $stringkey,
+            'component' => 'antivirus_mimeblocker',
+            'placeholders' => ['types' => $this->get_file_extensions()],
+        ];
     }
 
     /**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -124,7 +124,8 @@ class scanner extends \core\antivirus\scanner {
             }
         }
 
-        return $return;
+        // Unreachable in practice, but return a valid constant as a safeguard.
+        return self::SCAN_RESULT_ERROR;
     }
 
     /**

--- a/lang/en/antivirus_mimeblocker.php
+++ b/lang/en/antivirus_mimeblocker.php
@@ -31,6 +31,11 @@ $string['unknownerror'] = 'There was an unknown error with Mime Blocker.';
 $string['allowedmimetypes'] = 'Allowed mime types';
 $string['allowedmimetypesdesc'] =
         'Provide a list of allowed mimetypes separated by ";". For example: "text/xml;image/png;application/pdf"';
-$string['virusfound'] = ' You can only upload one of the following file types : {$a->types}.';
+$string['virusfoundallow'] = ' You can only upload one of the following file types : {$a->types}.';
+$string['virusfounddeny'] = ' You can not upload one of the following file types : {$a->types}.';
 $string['invalidtypes'] = 'The provided list contains invalid types';
-
+$string['scanmode'] = 'Choose scanmode';
+$string['scanmodedesc'] = 'Choose between two modi. Allow-Mode: all Mimetypes listed below will be accepted. 
+        Deny-Mode: all below listed Mimetypes will be blocked.';
+$string['scanmodeallow'] = 'Allow-Mode';
+$string['scanmodedeny'] = 'Deny-Mode';

--- a/lang/en/antivirus_mimeblocker.php
+++ b/lang/en/antivirus_mimeblocker.php
@@ -24,18 +24,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author     Tasos Koutoumanos <tk@eummena.org>
  */
+$string['invalidtypes'] = 'The provided list contains invalid types';
+$string['mimetypes'] = 'Mimetypes';
+$string['mimetypesdesc'] =
+        'Provide a list of configured mimetypes to handle separated by ";". For example: "text/xml;image/png;application/pdf"';
 $string['pluginname'] = 'Mime Blocker antivirus';
 $string['privacy:metadata'] = 'The Mime Blocker antivirus plugin does not store any personal data.';
 $string['quarantinedir'] = 'Quarantine directory';
-$string['unknownerror'] = 'There was an unknown error with Mime Blocker.';
-$string['allowedmimetypes'] = 'Allowed mime types';
-$string['allowedmimetypesdesc'] =
-        'Provide a list of allowed mimetypes separated by ";". For example: "text/xml;image/png;application/pdf"';
-$string['virusfoundallow'] = ' You can only upload one of the following file types : {$a->types}.';
-$string['virusfounddeny'] = ' You can not upload one of the following file types : {$a->types}.';
-$string['invalidtypes'] = 'The provided list contains invalid types';
 $string['scanmode'] = 'Choose scanmode';
 $string['scanmodedesc'] = 'Choose between two modi. Allow-Mode: all Mimetypes listed below will be accepted. 
         Deny-Mode: all below listed Mimetypes will be blocked.';
 $string['scanmodeallow'] = 'Allow-Mode';
 $string['scanmodedeny'] = 'Deny-Mode';
+$string['unknownerror'] = 'There was an unknown error with Mime Blocker.';
+$string['virusfoundallow'] = ' You can only upload one of the following file types : {$a->types}.';
+$string['virusfounddeny'] = ' You can not upload one of the following file types : {$a->types}.';

--- a/lang/en/antivirus_mimeblocker.php
+++ b/lang/en/antivirus_mimeblocker.php
@@ -37,5 +37,5 @@ $string['scanmodedesc'] = 'Choose between two modi. Allow-Mode: all Mimetypes li
 $string['scanmodeallow'] = 'Allow-Mode';
 $string['scanmodedeny'] = 'Deny-Mode';
 $string['unknownerror'] = 'There was an unknown error with Mime Blocker.';
-$string['virusfoundallow'] = ' You can only upload one of the following file types : {$a->types}.';
-$string['virusfounddeny'] = ' You can not upload one of the following file types : {$a->types}.';
+$string['virusfoundallow'] = 'You can only upload one of the following file types: {$a->types}.';
+$string['virusfounddeny'] = 'You cannot upload one of the following file types: {$a->types}.';

--- a/settings.php
+++ b/settings.php
@@ -30,7 +30,17 @@ if ($ADMIN->fulltree) {
     require_once(__DIR__ . '/classes/adminlib.php');
     require_once(__DIR__ . '/classes/scanner.php');
 
-    // Allowed mimetypes.
+    // Scanmode.
+    $settings->add(new admin_setting_configselect('antivirus_mimeblocker/scanmode',
+    new lang_string('scanmode', 'antivirus_mimeblocker'),
+    new lang_string('scanmodedesc', 'antivirus_mimeblocker'),
+    '0',
+    [
+        'allow' => new lang_string('scanmodeallow', 'antivirus_mimeblocker'),
+        'deny' => new lang_string('scanmodedeny', 'antivirus_mimeblocker')
+    ]));
+
+    // Mimetypes.
     $settings->add(new antivirus_mimeblocker_allowedmimetypes(
             'antivirus_mimeblocker/allowedmimetypes', new lang_string('allowedmimetypes', 'antivirus_mimeblocker'),
             new lang_string('allowedmimetypesdesc', 'antivirus_mimeblocker'), ''));

--- a/settings.php
+++ b/settings.php
@@ -42,6 +42,6 @@ if ($ADMIN->fulltree) {
 
     // Mimetypes.
     $settings->add(new antivirus_mimeblocker_allowedmimetypes(
-            'antivirus_mimeblocker/allowedmimetypes', new lang_string('allowedmimetypes', 'antivirus_mimeblocker'),
-            new lang_string('allowedmimetypesdesc', 'antivirus_mimeblocker'), ''));
+            'antivirus_mimeblocker/mimetypes', new lang_string('mimetypes', 'antivirus_mimeblocker'),
+            new lang_string('mimetypesdesc', 'antivirus_mimeblocker'), ''));
 }

--- a/settings.php
+++ b/settings.php
@@ -31,14 +31,16 @@ if ($ADMIN->fulltree) {
     require_once(__DIR__ . '/classes/scanner.php');
 
     // Scanmode.
-    $settings->add(new admin_setting_configselect('antivirus_mimeblocker/scanmode',
-    new lang_string('scanmode', 'antivirus_mimeblocker'),
-    new lang_string('scanmodedesc', 'antivirus_mimeblocker'),
-    'deny',
-    [
-        'allow' => new lang_string('scanmodeallow', 'antivirus_mimeblocker'),
-        'deny' => new lang_string('scanmodedeny', 'antivirus_mimeblocker')
-    ]));
+    $settings->add(new admin_setting_configselect(
+        'antivirus_mimeblocker/scanmode',
+        new lang_string('scanmode', 'antivirus_mimeblocker'),
+        new lang_string('scanmodedesc', 'antivirus_mimeblocker'),
+        'deny',
+        [
+            'allow' => new lang_string('scanmodeallow', 'antivirus_mimeblocker'),
+            'deny' => new lang_string('scanmodedeny', 'antivirus_mimeblocker'),
+        ]
+    ));
 
     // Mimetypes.
     $settings->add(new antivirus_mimeblocker_allowedmimetypes(

--- a/settings.php
+++ b/settings.php
@@ -34,7 +34,7 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('antivirus_mimeblocker/scanmode',
     new lang_string('scanmode', 'antivirus_mimeblocker'),
     new lang_string('scanmodedesc', 'antivirus_mimeblocker'),
-    '0',
+    'deny',
     [
         'allow' => new lang_string('scanmodeallow', 'antivirus_mimeblocker'),
         'deny' => new lang_string('scanmodedeny', 'antivirus_mimeblocker')

--- a/tests/scanner_test.php
+++ b/tests/scanner_test.php
@@ -69,8 +69,10 @@ final class scanner_test extends \advanced_testcase {
         ];
         $antivirus->method('get_config')->will($this->returnValueMap($configmap));
 
-        // Reinitialise the configured mimetypes from the mocked config.
-        $antivirus->configuredmimetypes = explode(';', trim($mimetypes));
+        // Reinitialise the configured mimetypes from the mocked config via reflection,
+        // since the property is protected.
+        $reflection = new \ReflectionProperty($antivirus, 'configuredmimetypes');
+        $reflection->setValue($antivirus, explode(';', trim($mimetypes)));
 
         return $antivirus;
     }

--- a/tests/scanner_test.php
+++ b/tests/scanner_test.php
@@ -24,8 +24,8 @@ namespace antivirus_mimeblocker;
  * @copyright  2026 MBS
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+#[\PHPUnit\Framework\Attributes\CoversClass(\antivirus_mimeblocker\scanner::class)]
 final class scanner_test extends \advanced_testcase {
-
     /** @var string Temporary file used in testing. */
     protected $tempfile;
 
@@ -71,6 +71,34 @@ final class scanner_test extends \advanced_testcase {
 
         // Reinitialise the configured mimetypes from the mocked config via reflection,
         // since the property is protected.
+        $reflection = new \ReflectionProperty($antivirus, 'configuredmimetypes');
+        $reflection->setValue($antivirus, explode(';', trim($mimetypes)));
+
+        return $antivirus;
+    }
+
+    /**
+     * Helper: create a scanner with real MIME detection and only get_config stubbed.
+     *
+     * Unlike create_scanner_mock(), detect_mimetype() is NOT mocked, so finfo
+     * inspects the actual file content. Used to verify content-based detection
+     * end to end (e.g. a .txt file containing a shebang is not text/plain).
+     *
+     * @param string $scanmode 'allow' or 'deny'.
+     * @param string $mimetypes Semicolon-separated configured MIME types.
+     * @return scanner
+     */
+    private function create_scanner_real_detection(string $scanmode, string $mimetypes): scanner {
+        $antivirus = $this->getMockBuilder('\antivirus_mimeblocker\scanner')
+            ->onlyMethods(['get_config'])
+            ->getMock();
+
+        $configmap = [
+            ['scanmode', $scanmode],
+            ['mimetypes', $mimetypes],
+        ];
+        $antivirus->method('get_config')->will($this->returnValueMap($configmap));
+
         $reflection = new \ReflectionProperty($antivirus, 'configuredmimetypes');
         $reflection->setValue($antivirus, explode(';', trim($mimetypes)));
 
@@ -179,5 +207,89 @@ final class scanner_test extends \advanced_testcase {
         $this->assertEquals('antivirus_mimeblocker', $message['component']);
         $this->assertEquals('virusfoundallow', $message['string']);
         $this->assertArrayHasKey('types', $message['placeholders']);
+    }
+
+    /**
+     * Real detection: genuine plain text content in a .txt file passes in allow mode.
+     *
+     * This is the manual "Test 1" scenario: allow mode with
+     * text/plain;image/png;application/pdf and a plain text upload.
+     */
+    public function test_scan_file_real_detection_plain_text(): void {
+        $scanner = $this->create_scanner_real_detection('allow', 'text/plain;image/png;application/pdf');
+        file_put_contents($this->tempfile, "Hallo Welt\nls -la\ncd /tmp\n");
+
+        $result = $scanner->scan_file($this->tempfile, 'befehle.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
+    }
+
+    /**
+     * Real detection: a .txt file starting with a shebang is detected as
+     * text/x-shellscript by content, not text/plain, and therefore blocked
+     * in allow mode. Detection is content-based, the extension is irrelevant.
+     */
+    public function test_scan_file_real_detection_shebang_in_txt_blocked(): void {
+        $scanner = $this->create_scanner_real_detection('allow', 'text/plain;image/png;application/pdf');
+        file_put_contents($this->tempfile, "#!/bin/bash\necho hallo\n");
+
+        $result = $scanner->scan_file($this->tempfile, 'befehle.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+    }
+
+    /**
+     * Real detection: an empty file is detected as application/x-empty
+     * and blocked in allow mode unless that type is configured.
+     */
+    public function test_scan_file_real_detection_empty_file_blocked(): void {
+        $scanner = $this->create_scanner_real_detection('allow', 'text/plain;image/png;application/pdf');
+        // Tempfile is created empty by setUp().
+
+        $result = $scanner->scan_file($this->tempfile, 'leer.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+    }
+
+    /**
+     * Real detection: binary content (PNG magic bytes) is detected as image/png,
+     * passing in allow mode and blocked in deny mode.
+     */
+    public function test_scan_file_real_detection_png(): void {
+        // Minimal valid PNG header (signature + IHDR chunk).
+        $png = "\x89PNG\r\n\x1a\n" . pack('N', 13) . 'IHDR'
+            . pack('N', 1) . pack('N', 1) . "\x08\x02\x00\x00\x00" . pack('N', 0x907753de);
+        file_put_contents($this->tempfile, $png);
+
+        $scanner = $this->create_scanner_real_detection('allow', 'text/plain;image/png;application/pdf');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $scanner->scan_file($this->tempfile, 'bild.png'));
+
+        $scanner = $this->create_scanner_real_detection('deny', 'image/png');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $scanner->scan_file($this->tempfile, 'bild.png'));
+    }
+
+    /**
+     * MoodleNet compatibility: an empty file detected as inode/x-empty with a
+     * .log extension is treated as text/plain.
+     */
+    public function test_scan_file_empty_log_file_treated_as_text_plain(): void {
+        $logfile = $this->tempfile . '.log';
+        touch($logfile);
+
+        $scanner = $this->create_scanner_mock('inode/x-empty', 'allow', 'text/plain');
+        $result = $scanner->scan_file($logfile, 'backup.log');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
+
+        unlink($logfile);
+    }
+
+    /**
+     * Gzip compatibility: gzip MIME types are treated as Moodle backup files.
+     */
+    public function test_scan_file_gzip_treated_as_moodle_backup(): void {
+        $scanner = $this->create_scanner_mock('application/x-gzip', 'allow', 'application/vnd.moodle.backup');
+        $result = $scanner->scan_file($this->tempfile, 'backup.mbz');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
+
+        $scanner = $this->create_scanner_mock('application/gzip', 'allow', 'application/vnd.moodle.backup');
+        $result = $scanner->scan_file($this->tempfile, 'backup.mbz');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
     }
 }

--- a/tests/scanner_test.php
+++ b/tests/scanner_test.php
@@ -1,0 +1,158 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace antivirus_mimeblocker;
+
+/**
+ * Tests for mimeblocker antivirus scanner class.
+ *
+ * @package    antivirus_mimeblocker
+ * @category   test
+ * @copyright  2026 MBS
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class scanner_test extends \advanced_testcase {
+
+    /** @var string Temporary file used in testing. */
+    protected $tempfile;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+
+        // Create tempfile.
+        $tempfolder = make_request_directory(false);
+        $this->tempfile = $tempfolder . '/' . rand();
+        touch($this->tempfile);
+    }
+
+    protected function tearDown(): void {
+        @unlink($this->tempfile);
+        parent::tearDown();
+    }
+
+    /**
+     * Helper: create a scanner mock with detect_mimetype and get_config stubbed.
+     *
+     * We mock detect_mimetype() because finfo_file() is always available in the
+     * test environment and will always return a real MIME type. Mocking lets us
+     * simulate undetectable files (null) and control the exact MIME type without
+     * needing real files of each type on disk.
+     *
+     * @param string|null $mimetype The MIME type that detect_mimetype should return.
+     * @param string $scanmode 'allow' or 'deny'.
+     * @param string $mimetypes Semicolon-separated configured MIME types.
+     * @return scanner
+     */
+    private function create_scanner_mock(?string $mimetype, string $scanmode, string $mimetypes): scanner {
+        $antivirus = $this->getMockBuilder('\antivirus_mimeblocker\scanner')
+            ->onlyMethods(['detect_mimetype', 'get_config'])
+            ->getMock();
+
+        $antivirus->method('detect_mimetype')->willReturn($mimetype);
+        $configmap = [
+            ['scanmode', $scanmode],
+            ['mimetypes', $mimetypes],
+        ];
+        $antivirus->method('get_config')->will($this->returnValueMap($configmap));
+
+        // Reinitialise the configured mimetypes from the mocked config.
+        $antivirus->configuredmimetypes = explode(';', trim($mimetypes));
+
+        return $antivirus;
+    }
+
+    /**
+     * When MIME detection returns null (no detection function available),
+     * the scanner should return SCAN_RESULT_ERROR regardless of scan mode.
+     *
+     * This means the admin's "Action on scan failure" setting decides
+     * whether the upload is ultimately accepted or rejected — not the plugin.
+     */
+    public function test_scan_file_undetectable_mimetype_returns_error(): void {
+        // In allow mode, undetectable MIME → ERROR.
+        $scanner = $this->create_scanner_mock(null, 'allow', 'text/plain;image/png');
+        $result = $scanner->scan_file($this->tempfile, 'testfile.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_ERROR, $result);
+        $this->assertDebuggingCalled();
+
+        // In deny mode, undetectable MIME → ERROR (NOT silently passing).
+        $scanner = $this->create_scanner_mock(null, 'deny', 'application/x-msdownload');
+        $result = $scanner->scan_file($this->tempfile, 'testfile.exe');
+        $this->assertEquals(scanner::SCAN_RESULT_ERROR, $result);
+        $this->assertDebuggingCalled();
+    }
+
+    /**
+     * Allow mode: a file with an allowed MIME type should pass.
+     */
+    public function test_scan_file_allow_mode_allowed_type(): void {
+        $scanner = $this->create_scanner_mock('text/plain', 'allow', 'text/plain;image/png');
+        $result = $scanner->scan_file($this->tempfile, 'readme.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
+    }
+
+    /**
+     * Allow mode: a file with a non-allowed MIME type should be blocked.
+     */
+    public function test_scan_file_allow_mode_blocked_type(): void {
+        $scanner = $this->create_scanner_mock('application/x-msdownload', 'allow', 'text/plain;image/png');
+
+        $this->expectException(mimeblocker_exception::class);
+        $scanner->scan_file($this->tempfile, 'malware.exe');
+    }
+
+    /**
+     * Deny mode: a file with a denied MIME type should be blocked.
+     */
+    public function test_scan_file_deny_mode_blocked_type(): void {
+        $scanner = $this->create_scanner_mock('application/x-msdownload', 'deny', 'application/x-msdownload');
+
+        $this->expectException(mimeblocker_exception::class);
+        $scanner->scan_file($this->tempfile, 'malware.exe');
+    }
+
+    /**
+     * Deny mode: a file with a non-denied MIME type should pass.
+     */
+    public function test_scan_file_deny_mode_allowed_type(): void {
+        $scanner = $this->create_scanner_mock('text/plain', 'deny', 'application/x-msdownload');
+        $result = $scanner->scan_file($this->tempfile, 'readme.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_OK, $result);
+    }
+
+    /**
+     * Unreadable file should return SCAN_RESULT_FOUND.
+     */
+    public function test_scan_file_not_readable(): void {
+        $scanner = $this->create_scanner_mock('text/plain', 'allow', 'text/plain');
+        $nonexistent = $this->tempfile . '_nonexistent';
+
+        $result = $scanner->scan_file($nonexistent, 'missing.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+        $this->assertDebuggingCalled();
+    }
+
+    /**
+     * Invalid scanmode config should return SCAN_RESULT_FOUND.
+     */
+    public function test_scan_file_invalid_scanmode(): void {
+        $scanner = $this->create_scanner_mock('text/plain', 'invalid', 'text/plain');
+
+        $result = $scanner->scan_file($this->tempfile, 'readme.txt');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+    }
+}

--- a/tests/scanner_test.php
+++ b/tests/scanner_test.php
@@ -110,9 +110,8 @@ final class scanner_test extends \advanced_testcase {
      */
     public function test_scan_file_allow_mode_blocked_type(): void {
         $scanner = $this->create_scanner_mock('application/x-msdownload', 'allow', 'text/plain;image/png');
-
-        $this->expectException(mimeblocker_exception::class);
-        $scanner->scan_file($this->tempfile, 'malware.exe');
+        $result = $scanner->scan_file($this->tempfile, 'malware.exe');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
     }
 
     /**
@@ -120,9 +119,8 @@ final class scanner_test extends \advanced_testcase {
      */
     public function test_scan_file_deny_mode_blocked_type(): void {
         $scanner = $this->create_scanner_mock('application/x-msdownload', 'deny', 'application/x-msdownload');
-
-        $this->expectException(mimeblocker_exception::class);
-        $scanner->scan_file($this->tempfile, 'malware.exe');
+        $result = $scanner->scan_file($this->tempfile, 'malware.exe');
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
     }
 
     /**
@@ -154,5 +152,30 @@ final class scanner_test extends \advanced_testcase {
 
         $result = $scanner->scan_file($this->tempfile, 'readme.txt');
         $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+    }
+
+    /**
+     * When a blocked file is rejected, the temp file should still exist afterward
+     * so the antivirus manager can quarantine it, and get_virus_found_message()
+     * should return the structure the manager needs to display the error.
+     */
+    public function test_scan_file_blocked_does_not_delete_file(): void {
+        $scanner = $this->create_scanner_mock('application/x-msdownload', 'allow', 'text/plain;image/png');
+        $result = $scanner->scan_file($this->tempfile, 'malware.exe');
+
+        // The manager expects SCAN_RESULT_FOUND to trigger quarantine + cleanup.
+        $this->assertEquals(scanner::SCAN_RESULT_FOUND, $result);
+
+        // The file must still exist so the manager can quarantine it before deleting.
+        $this->assertFileExists($this->tempfile, 'Scanner should not delete the file — the antivirus manager handles cleanup');
+
+        // The manager calls get_virus_found_message() to build the user-facing exception.
+        $message = $scanner->get_virus_found_message();
+        $this->assertArrayHasKey('string', $message);
+        $this->assertArrayHasKey('component', $message);
+        $this->assertArrayHasKey('placeholders', $message);
+        $this->assertEquals('antivirus_mimeblocker', $message['component']);
+        $this->assertEquals('virusfoundallow', $message['string']);
+        $this->assertArrayHasKey('types', $message['placeholders']);
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023022001;              // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2023022004;              // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires = 2018050800;               // Requires this Moodle version.
 $plugin->release = '3.5';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023022004;              // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version = 2023022006;              // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires = 2018050800;               // Requires this Moodle version.
 $plugin->release = '3.5';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
I played around with the idea of my feature request and made a small adjustment.
With this setting, two different lists for the mime types (allow and deny) are unnecessary.

I will attach a second commit with a refactoring afterwards.

If the idea is good for you, I could add a unit test for the new setting. 

Many greetings



